### PR TITLE
Small fixes for bench.py --device=cpu

### DIFF
--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -60,7 +60,7 @@ def bench(input_shape, partition_shape, width, modes, nt, dev, ngpu, benchmark_t
 
     P_x._comm.Barrier()
     errors = False
-    
+
     try:
         x_shape = input_shape
         y_shape = (*input_shape[:-1], nt)
@@ -71,8 +71,8 @@ def bench(input_shape, partition_shape, width, modes, nt, dev, ngpu, benchmark_t
             x = torch.rand(size=tuple(x_info['shape']), device=device, dtype=torch.float32)
             network = DistributedFNO(P_x, x_shape, nt, width, modes, device=device, dtype=torch.float32)
             network.eval()
-        
-            
+
+
             if benchmark_type == 'eval':
                 with torch.no_grad():
                     print0("fake eval", P_0)


### PR DESCRIPTION
Fix two minor things in bench.py for `--device=cpu`:

* don't require --num-gpus=1
* don't open a cupy context manager

This fixes the following exception:
```
% python3 bench.py --partition_shape 1 1 1 1 1 1 --input-shape 1 1 64 32 32 1 --modes 4 2 2 2 --device=cpu              
Traceback (most recent call last):
  File "/home/infinoid/workspace/fno/devel/dfno/dfno/benchmarks/bench.py", line 163, in <module>
    bench(input_shape, partition_shape, width, modes, nt, device, ngpu, benchmark_type, output_dir)
  File "/home/infinoid/workspace/fno/devel/dfno/dfno/benchmarks/bench.py", line 34, in bench
    device_ordinal = P_x.rank % ngpu
ZeroDivisionError: integer division or modulo by zero
```

There's no point in calculating a device ordinal when cuda is not enabled.  The default `ngpu` (--num-gpus) is 0, which is reasonable in CPU-only mode.
