### PR TITLE
Update benchmarks/bench.py to use the right module name

### DIFF
--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -13,7 +13,7 @@ import traceback
 from mpi4py import MPI
 import cupy
 
-from utils import profile_gpu_memory, compute_distribution_info
+from dfno import profile_gpu_memory, compute_distribution_info
 
 def dls(l, delimiter='_'):
     out = ''


### PR DESCRIPTION
I've been trying to run bench.py and getting `ModuleNotFoundError`s.  It seems that `from dfno` works better than `from utils`.

I started with a fresh git clone of dfno, and installed it as a pip package.  bench.py didn't work:
```
% python3 bench.py --help
Traceback (most recent call last):
  File "/home/infinoid/workspace/fno/learning/perlmutter/dfno/dfno/benchmarks/bench.py", line 16, in <module>
    from utils import profile_gpu_memory, compute_distribution_info
ModuleNotFoundError: No module named 'utils'
```

I changed `from utils` to `from dfno` in the bench.py script, and it worked.

Then I did a `pip3 uninstall dfno` and set `PYTHONPATH=..` and it still works.  So it should be compatible with the perlmutter instructions in PR #6, too.
